### PR TITLE
argparse dependency for deb packages with py<2.7

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Package: python-obspy
 Architecture: any
 Section: python
 Priority: extra
-Depends: python (>= 2.6), python (<< 3), ${python:Depends},
+Depends: python (>= 2.6), python (>= 2.7) | python-argparse,
+ python (<< 3), ${python:Depends},
  python-numpy (>= 1:1.1), python-setuptools (>= 0.6), python-lxml (>= 2.1),
  python-matplotlib (>= 0.98.1), python-scipy, python-sqlalchemy,
  python-suds (>= 0.4), ${shlibs:Depends}, python-tornado


### PR DESCRIPTION
should probably work also without the "|" operator as at least wheezy
seems to contain a dummy package for python-argparse provided by
python2.7 itself. Seems safer this way though, no idea when/if these
virtual packages will be dropped.
